### PR TITLE
Really set 'latest_builds' to the latest value of the day

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -279,6 +279,7 @@ sources:
 	@$(MAKE) generateupstream; \
 	[ $$? -eq 0 ] && exit 0; \
 	nvr="$$(rpmspec --srpm -q --qf '%{NAME}\t%{VERSION}\t%{RELEASE}\n' $(SPECFILE))"; \
+	git -C $(TOPLVL)/projects/common fetch --tags >/dev/null 2>&1; \
 	latest_builds=$$(git -C $(TOPLVL)/projects/common tag -l | sort -rn); \
 	for b in $$latest_builds; do \
 		url="$(DOWNLOAD_MIRROR)/releases/$$b/clear/source/package-sources"; \


### PR DESCRIPTION
Consider the following scenario:
* System being set-up on day 0 (by running user-setup.sh script)
* The github.com/clearlinux/common repo is cloned under projects/common
* Fast-forward in the future
* Clone a package for which there is no reachable upstream URL
	(e.g. clr-power-tweaks or clr-systemd-config
* Run 'make sources'
That operation will fail because it will search for the src.rpm files starting
with the Clear Linux build determined by looking up the latest tag in the
project/common repo (and the latest is the one from day 0). So it will only find
older versions of those src.rpm, and will eventually fail.

This patch adds a line that fetches all the latest tags from the upstream
projects/common repo so the 'latest_builds' variable is *really* set to the
latest of the day.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>