### PR TITLE
Output cargo vendor requirements to text file

### DIFF
--- a/vendor.py
+++ b/vendor.py
@@ -75,9 +75,10 @@ def update_cargo_vendor(path, name, git):
     shutil.rmtree(vendor_path)
     cargo_vendors = subprocess.run('cargo vendor', cwd=path, shell=True, check=True,
                             stdout=subprocess.PIPE, universal_newlines=True).stdout
-    vendors_file = os.path.join(vendor_path, 'vendors.txt')
-    with open(vendors_file, 'w') as f:
-        f.write(cargo_vendors)
+    if 'git' in cargo_vendors:
+        vendors_file = os.path.join(vendor_path, 'vendors.txt')
+        with open(vendors_file, 'w') as f:
+            f.write(cargo_vendors)
     subprocess.run(f"cp -a {backup_vendor_git} {vendor_git}", cwd=path,
                    shell=True, check=True, stdout=subprocess.DEVNULL)
     repo = Repo(vendor_path)

--- a/vendor.py
+++ b/vendor.py
@@ -9,9 +9,8 @@ import subprocess
 import tempfile
 import time
 
-from git import Repo
-
 import requests
+from git import Repo
 
 
 def vendor_check():
@@ -74,8 +73,11 @@ def update_cargo_vendor(path, name, git):
     subprocess.run(f"cp -a {vendor_git} {backup_vendor_git}", cwd=path,
                    shell=True, check=True, stdout=subprocess.DEVNULL)
     shutil.rmtree(vendor_path)
-    subprocess.run('cargo vendor', cwd=path, shell=True, check=True,
-                   stdout=subprocess.DEVNULL)
+    cargo_vendors = subprocess.run('cargo vendor', cwd=path, shell=True, check=True,
+                            stdout=subprocess.PIPE, universal_newlines=True).stdout
+    vendors_file = os.path.join(vendor_path, 'vendors.txt')
+    with open(vendors_file, 'w') as f:
+        f.write(cargo_vendors)
     subprocess.run(f"cp -a {backup_vendor_git} {vendor_git}", cwd=path,
                    shell=True, check=True, stdout=subprocess.DEVNULL)
     repo = Repo(vendor_path)


### PR DESCRIPTION
The resulting file can then be appended to .cargo/config.toml rather than using echo.
Addresses https://github.com/clearlinux/autospec/issues/837